### PR TITLE
Add benchmarks for realtime reader and optimise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,14 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+crossbeam-utils = "0.8.19"
 
 [target.'cfg(loom)'.dependencies]
 loom = "0.7.1"
+
+[dev-dependencies]
+criterion = { version = "0.5.1", features = ["html_reports"] }
+
+[[bench]]
+name = "reader"
+harness = false

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -1,0 +1,65 @@
+use {
+    criterion::{criterion_group, criterion_main, Bencher, Criterion},
+    real_time::reader,
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread,
+    },
+};
+
+fn writer(bencher: &mut Bencher) {
+    let (mut writer, mut reader) = reader::realtime_reader(0);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let handle = thread::spawn({
+        let stop = Arc::clone(&stop);
+        move || loop {
+            for _ in 0..1000 {
+                let _ = reader.get();
+            }
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+        }
+    });
+
+    bencher.iter(|| writer.set(1));
+
+    stop.store(true, Ordering::Relaxed);
+    handle.join().unwrap();
+}
+
+fn reader(bencher: &mut Bencher) {
+    let (mut writer, mut reader) = reader::realtime_reader(0);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let handle = thread::spawn({
+        let stop = Arc::clone(&stop);
+        move || loop {
+            for _ in 0..1000 {
+                let _ = writer.set(1);
+            }
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+        }
+    });
+
+    bencher.iter(|| {
+        let _ = reader.get();
+    });
+
+    stop.store(true, Ordering::Relaxed);
+    handle.join().unwrap();
+}
+
+fn realtime_reader_benchmark(c: &mut Criterion) {
+    c.bench_function("writer", writer);
+    c.bench_function("reader", reader);
+}
+
+criterion_group!(benches, realtime_reader_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
- Use `CachePadded` to avoid false sharing on the reader
- Use `Backoff` to reduce contention