### PR TITLE
Make all real-time objects unsync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ loom = "0.7.1"
 [dev-dependencies]
 beady = "0.6.1"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+static_assertions = "1.1.0"
 
 [[bench]]
 name = "reader"

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -32,7 +32,7 @@ impl Default for Big {
 #[test]
 fn reading_on_real_time_thread_with_multiple_simultaneously_writers() {
     loom::model(|| {
-        let (writer, mut reader) = realtime_reader(Big::default());
+        let (writer, reader) = realtime_reader(Big::default());
         let writer = Arc::new(Mutex::new(writer));
 
         const WRITERS: i64 = 2;
@@ -60,7 +60,7 @@ fn reading_on_real_time_thread_with_multiple_simultaneously_writers() {
 #[test]
 fn writing_on_real_time_thread_with_multiple_simultaneously_readers() {
     loom::model(|| {
-        let (reader, mut writer) = realtime_writer(Big::default());
+        let (reader, writer) = realtime_writer(Big::default());
         let reader = Arc::new(Mutex::new(reader));
 
         const READERS: i64 = 2;


### PR DESCRIPTION
And don't require them to be mutable to use