### PR TITLE
Make RealtimeReader::read require unique borrow

### DIFF
--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -5,7 +5,7 @@ use {
 };
 
 fn writer(bencher: &mut Bencher) {
-    let (writer, reader) = readable(0);
+    let (writer, mut reader) = readable(0);
 
     thread::spawn({
         move || loop {
@@ -18,7 +18,7 @@ fn writer(bencher: &mut Bencher) {
 }
 
 fn reader(bencher: &mut Bencher) {
-    let (writer, reader) = readable(0);
+    let (writer, mut reader) = readable(0);
 
     thread::spawn({
         move || loop {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -275,15 +275,15 @@ impl<T> RealtimeWriter<T> {
 mod test {
     use {
         super::*,
-        static_assertions::{assert_impl_all, assert_not_impl_all},
+        static_assertions::{assert_impl_all, assert_not_impl_any},
         std::{sync::atomic::AtomicUsize, thread},
     };
 
     assert_impl_all!(RealtimeWriter<i32>: Send);
-    assert_not_impl_all!(RealtimeWriter<i32>: Sync, Copy, Clone);
+    assert_not_impl_any!(RealtimeWriter<i32>: Sync, Copy, Clone);
 
     assert_impl_all!(LockingReader<i32>: Send);
-    assert_not_impl_all!(LockingReader<i32>: Sync, Copy, Clone);
+    assert_not_impl_any!(LockingReader<i32>: Sync, Copy, Clone);
 
     #[test]
     fn determining_the_read_and_write_indexes() {


### PR DESCRIPTION
This prevents user calling read twice